### PR TITLE
Pin dependency versions and add audit workflow

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,36 @@
+name: Dependency Review
+
+on:
+  schedule:
+    - cron: '0 0 * * 0'
+  workflow_dispatch:
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install backend dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r backend/requirements.txt
+      - name: Run pip-audit
+        run: |
+          python -m pip install pip-audit
+          pip-audit -r backend/requirements.txt
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+      - name: Install frontend dependencies
+        run: |
+          cd frontend
+          npm ci
+      - name: Run npm audit
+        run: |
+          cd frontend
+          npm audit --audit-level=moderate

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,6 +1,6 @@
-Django>=4.2,<5.0
-djangorestframework>=3.14
-django-cors-headers>=4.3
-django-filter>=23.5
-Pillow>=9.5
-gunicorn>=21.2
+Django==4.2.10
+djangorestframework==3.14.0
+django-cors-headers==4.3.1
+django-filter==23.5
+Pillow==9.5.0
+gunicorn==21.2.0

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,19 +8,19 @@
       "name": "supermercado-frontend",
       "version": "0.1.0",
       "dependencies": {
-        "framer-motion": "^12.23.12",
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0",
-        "react-router-dom": "^6.22.3",
-        "sonner": "^2.0.7"
+        "framer-motion": "12.23.12",
+        "react": "18.2.0",
+        "react-dom": "18.2.0",
+        "react-router-dom": "6.22.3",
+        "sonner": "2.0.7"
       },
       "devDependencies": {
-        "@vitejs/plugin-react": "^4.3.0",
-        "autoprefixer": "^10.4.17",
-        "connect-history-api-fallback": "^2.0.0",
-        "postcss": "^8.4.35",
-        "tailwindcss": "^3.4.10",
-        "vite": "^5.0.10"
+        "@vitejs/plugin-react": "4.3.0",
+        "autoprefixer": "10.4.17",
+        "connect-history-api-fallback": "2.0.0",
+        "postcss": "8.4.35",
+        "tailwindcss": "3.4.10",
+        "vite": "5.0.10"
       }
     },
     "node_modules/@alloc/quick-lru": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,18 +9,18 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "framer-motion": "^12.23.12",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
-    "react-router-dom": "^6.22.3",
-    "sonner": "^2.0.7"
+    "framer-motion": "12.23.12",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "react-router-dom": "6.22.3",
+    "sonner": "2.0.7"
   },
   "devDependencies": {
-    "@vitejs/plugin-react": "^4.3.0",
-    "connect-history-api-fallback": "^2.0.0",
-    "autoprefixer": "^10.4.17",
-    "postcss": "^8.4.35",
-    "tailwindcss": "^3.4.10",
-    "vite": "^5.0.10"
+    "@vitejs/plugin-react": "4.3.0",
+    "connect-history-api-fallback": "2.0.0",
+    "autoprefixer": "10.4.17",
+    "postcss": "8.4.35",
+    "tailwindcss": "3.4.10",
+    "vite": "5.0.10"
   }
 }


### PR DESCRIPTION
## Summary
- pin backend requirements to exact versions
- pin frontend package versions and update lock file
- add weekly dependency audit workflow using pip-audit and npm audit

## Testing
- `python -m py_compile $(git ls-files 'backend/**/*.py')`
- `npm audit --audit-level=moderate` *(fails: 403 Forbidden to npm registry)*
- `pip install pip-audit` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68bf7ad4f6148330825a07aacc8a2a5e