### PR TITLE
Configure Django password validators

### DIFF
--- a/backend/supermercado/settings.py
+++ b/backend/supermercado/settings.py
@@ -64,7 +64,20 @@ DATABASES = {
     }
 }
 
-AUTH_PASSWORD_VALIDATORS = []
+AUTH_PASSWORD_VALIDATORS = [
+    {
+        'NAME': 'django.contrib.auth.password_validation.UserAttributeSimilarityValidator',
+    },
+    {
+        'NAME': 'django.contrib.auth.password_validation.MinimumLengthValidator',
+    },
+    {
+        'NAME': 'django.contrib.auth.password_validation.CommonPasswordValidator',
+    },
+    {
+        'NAME': 'django.contrib.auth.password_validation.NumericPasswordValidator',
+    },
+]
 
 LANGUAGE_CODE = 'es-ar'
 


### PR DESCRIPTION
## Summary
- add Django's recommended password validators to settings

## Testing
- `python backend/manage.py migrate`
- `python backend/manage.py shell -c "from django.contrib.auth.forms import UserCreationForm; f=UserCreationForm({'username':'john','password1':'1234','password2':'1234'}); print(f.is_valid()); print(f.errors.as_text())"`
- `python backend/manage.py shell -c "from django.contrib.auth.forms import UserCreationForm; f=UserCreationForm({'username':'john2','password1':'ComplexPass123','password2':'ComplexPass123'}); print(f.is_valid()); print(f.errors.as_text())"`
- `python backend/manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68bf7aca66088330a650584420f7ca7c