### PR TITLE
Use POST for coupon validation and improve error handling

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -39,10 +39,16 @@ export async function createOrder(payload) {
 }
 
 export async function validateCoupon(code) {
-  const url = new URL(`${API_URL}/coupons/validate/`)
-  url.searchParams.set('code', code)
-  const r = await fetch(url)
-  if (!r.ok) throw new Error('No se pudo validar el cupón')
+  const r = await fetch(`${API_URL}/coupons/validate/`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ code }),
+  })
+  if (!r.ok) {
+    let err
+    try { err = await r.json() } catch { err = { detail: 'No se pudo validar el cupón' } }
+    throw new Error(err.detail || JSON.stringify(err))
+  }
   return r.json()
 }
 


### PR DESCRIPTION
## Summary
- send coupon code in POST body for validation
- add JSON error handling when coupon validation fails

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`
- `python manage.py shell` to validate coupons with valid, invalid, and missing codes


------
https://chatgpt.com/codex/tasks/task_e_68bf816b9b9c83308d79c451c380882c