### PR TITLE
Configure database using DATABASE_URL

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -8,6 +8,7 @@ django-storages[boto3]==1.14.6
 djangorestframework==3.14.0
 cloudinary==1.41.0
 django-cloudinary-storage==0.3.0
+dj-database-url==3.0.1
 gunicorn==21.2.0
 iniconfig==2.1.0
 isort==6.0.1

--- a/backend/supermercado/settings.py
+++ b/backend/supermercado/settings.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 import os
+
+import dj_database_url
 from django.core.exceptions import ImproperlyConfigured
 
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -67,16 +69,23 @@ TEMPLATES = [
 
 WSGI_APPLICATION = 'supermercado.wsgi.application'
 
-DATABASES = {
-    "default": {
-        "ENGINE": "django.db.backends.postgresql",
-        "HOST": os.getenv("DJANGO_DB_HOST", "localhost"),
-        "PORT": os.getenv("DJANGO_DB_PORT", "5432"),
-        "NAME": os.getenv("DJANGO_DB_NAME", ""),
-        "USER": os.getenv("DJANGO_DB_USER", ""),
-        "PASSWORD": os.getenv("DJANGO_DB_PASSWORD", ""),
+DATABASE_URL = os.environ.get("DATABASE_URL")
+
+if DATABASE_URL:
+    DATABASES = {
+        "default": dj_database_url.config(
+            default=DATABASE_URL,
+            conn_max_age=0 if DEBUG else 600,
+            ssl_require=not DEBUG,
+        )
     }
-}
+else:
+    DATABASES = {
+        "default": {
+            "ENGINE": "django.db.backends.sqlite3",
+            "NAME": BASE_DIR / "db.sqlite3",
+        }
+    }
 
 AUTH_PASSWORD_VALIDATORS = []
 


### PR DESCRIPTION
## Summary
- use dj-database-url and DATABASE_URL env var for database config with SQLite fallback
- add dj-database-url to backend requirements

## Testing
- `DJANGO_SECRET_KEY=testing-secret DJANGO_DEBUG=True DJANGO_ALLOWED_HOSTS=localhost python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68c20ca12ed88330bbe6b702c4262c0d