### PR TITLE
Allow unauthenticated access to catalog endpoints

### DIFF
--- a/backend/shop/views.py
+++ b/backend/shop/views.py
@@ -31,6 +31,7 @@ from .serializers import (
 class CategoryViewSet(mixins.ListModelMixin, mixins.RetrieveModelMixin, viewsets.GenericViewSet):
     queryset = Category.objects.all()
     serializer_class = CategorySerializer
+    permission_classes = [AllowAny]
 
 
 class ProductPagination(PageNumberPagination):
@@ -40,6 +41,7 @@ class ProductPagination(PageNumberPagination):
 class ProductViewSet(mixins.ListModelMixin, mixins.RetrieveModelMixin, viewsets.GenericViewSet):
     queryset = Product.objects.filter(is_active=True).select_related('category')
     serializer_class = ProductSerializer
+    permission_classes = [AllowAny]
     filter_backends = [DjangoFilterBackend, SearchFilter, OrderingFilter]
     filterset_fields = ['category', 'promoted']
     search_fields = ['name', 'description']

--- a/backend/supermercado/settings.py
+++ b/backend/supermercado/settings.py
@@ -123,7 +123,7 @@ REST_FRAMEWORK = {
         'rest_framework.authentication.SessionAuthentication',
     ],
     'DEFAULT_PERMISSION_CLASSES': [
-        'rest_framework.permissions.IsAuthenticated',
+        'rest_framework.permissions.AllowAny',
     ],
     'DEFAULT_FILTER_BACKENDS': [
         'django_filters.rest_framework.DjangoFilterBackend',


### PR DESCRIPTION
## Summary
- default REST framework permissions allow any request
- expose categories and products endpoints without authentication

## Testing
- `DJANGO_SECRET_KEY=testing DJANGO_DEBUG=1 python backend/manage.py test`
- `curl -s http://localhost:8000/api/categories/ | head -n 20`
- `curl -s http://localhost:8000/api/products/ | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68c41171bdb88330845cdadfccabbfba