### PR TITLE
Allow unauthenticated access to catalog endpoints and refine cart layout

### DIFF
--- a/backend/shop/views.py
+++ b/backend/shop/views.py
@@ -31,6 +31,7 @@ from .serializers import (
 class CategoryViewSet(mixins.ListModelMixin, mixins.RetrieveModelMixin, viewsets.GenericViewSet):
     queryset = Category.objects.all()
     serializer_class = CategorySerializer
+    permission_classes = [AllowAny]
 
 
 class ProductPagination(PageNumberPagination):
@@ -40,6 +41,7 @@ class ProductPagination(PageNumberPagination):
 class ProductViewSet(mixins.ListModelMixin, mixins.RetrieveModelMixin, viewsets.GenericViewSet):
     queryset = Product.objects.filter(is_active=True).select_related('category')
     serializer_class = ProductSerializer
+    permission_classes = [AllowAny]
     filter_backends = [DjangoFilterBackend, SearchFilter, OrderingFilter]
     filterset_fields = ['category', 'promoted']
     search_fields = ['name', 'description']

--- a/backend/supermercado/settings.py
+++ b/backend/supermercado/settings.py
@@ -123,7 +123,7 @@ REST_FRAMEWORK = {
         'rest_framework.authentication.SessionAuthentication',
     ],
     'DEFAULT_PERMISSION_CLASSES': [
-        'rest_framework.permissions.IsAuthenticated',
+        'rest_framework.permissions.AllowAny',
     ],
     'DEFAULT_FILTER_BACKENDS': [
         'django_filters.rest_framework.DjangoFilterBackend',

--- a/frontend/src/components/cart/CartGrouped.jsx
+++ b/frontend/src/components/cart/CartGrouped.jsx
@@ -105,14 +105,12 @@ export default function CartGrouped({
                         onDecrement={() => quantity > 1 && onDec(product.id)}
                         onIncrement={() => quantity < max && onInc(product.id)}
                         onSet={(v) => onSetQty(product.id, v)}
-
-                        className="h-10 w-16"
-
+                        className="h-10 w-14 lg:w-16"
                       />
                     </div>
 
                     {/* Total + eliminar desktop */}
-                    <div className="hidden md:flex items-center justify-between gap-2">
+                    <div className="hidden md:flex items-center justify-end gap-2">
                       <span className="font-semibold text-orange-600 whitespace-nowrap">{formatArs(lineTotal)}</span>
                       <button
                         onClick={() => onRemove(product.id)}
@@ -120,9 +118,7 @@ export default function CartGrouped({
                         aria-label="Eliminar producto"
                         title="Eliminar producto"
                       >
-
                         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="w-7 h-7">
-
                           <path stroke="none" d="M0 0h24v24H0z" fill="none" />
                           <path d="M4 7l16 0" />
                           <path d="M10 11l0 6" />
@@ -131,9 +127,7 @@ export default function CartGrouped({
                           <path d="M9 7v-3a1 1 0 0 1 1 -1h4a1 1 0 0 1 1 1v3" />
                         </svg>
                       </button>
-                      <span className="font-semibold text-orange-600 whitespace-nowrap">{formatArs(lineTotal)}</span>
                     </div>
-
 
                     {/* Cantidad mobile */}
                     <QuantityStepper
@@ -143,26 +137,7 @@ export default function CartGrouped({
                       onDecrement={() => quantity > 1 && onDec(product.id)}
                       onIncrement={() => quantity < max && onInc(product.id)}
                       onSet={(v) => onSetQty(product.id, v)}
-
-                      className="md:hidden row-start-2 col-start-1 h-9 w-16"
-
-                    />
-
-                    {/* Total mobile */}
-                    <div className="md:hidden row-start-2 col-start-2 flex items-center justify-end">
-                      <span className="font-semibold text-orange-600 whitespace-nowrap">{formatArs(lineTotal)}</span>
-                    </div>
-
-
-                    {/* Cantidad mobile */}
-                    <QuantityStepper
-                      value={quantity}
-                      min={1}
-                      max={max}
-                      onDecrement={() => quantity > 1 && onDec(product.id)}
-                      onIncrement={() => quantity < max && onInc(product.id)}
-                      onSet={(v) => onSetQty(product.id, v)}
-                      className="md:hidden row-start-2 col-start-1 h-9 w-16"
+                      className="md:hidden row-start-2 col-start-1 h-9 w-14"
                     />
 
                     {/* Total mobile */}


### PR DESCRIPTION
## Summary
- default REST framework permissions allow any request
- expose categories and products endpoints without authentication
- remove duplicated cart line totals and make quantity selector responsive

## Testing
- `DJANGO_SECRET_KEY=testing DJANGO_DEBUG=1 python backend/manage.py test`
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c41171bdb88330845cdadfccabbfba