### PR TITLE
Add responsive margin to mobile quantity stepper

### DIFF
--- a/frontend/src/components/cart/CartGrouped.jsx
+++ b/frontend/src/components/cart/CartGrouped.jsx
@@ -162,7 +162,7 @@ export default function CartGrouped({
                       onDecrement={() => quantity > 1 && onDec(product.id)}
                       onIncrement={() => quantity < max && onInc(product.id)}
                       onSet={(v) => onSetQty(product.id, v)}
-                      className="min-[1000px]:hidden row-start-2 col-start-1 h-10 !w-5/12 justify-self-start -ml-4 scale-y-110"
+                      className="min-[1000px]:hidden row-start-2 col-start-1 h-10 !w-5/12 justify-self-start ml-4 sm:ml-8 lg:ml-12 scale-y-110"
                     />
 
                     {/* Total mobile */}


### PR DESCRIPTION
## Summary
- adjust mobile quantity stepper spacing with responsive left margin

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c434e4dfcc83309d8b6b82d073a44e