### PR TITLE
Add loading animation and error view for products

### DIFF
--- a/frontend/src/components/ui/ErrorView.jsx
+++ b/frontend/src/components/ui/ErrorView.jsx
@@ -1,0 +1,25 @@
+import React from 'react'
+
+export default function ErrorView({ message = 'Ocurrió un error' }) {
+  return (
+    <div className="flex flex-col items-center text-center py-16">
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="64"
+        height="64"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        className="text-red-600 mb-4"
+      >
+        <circle cx="12" cy="12" r="10" />
+        <line x1="12" y1="8" x2="12" y2="12" />
+        <line x1="12" y1="16" x2="12.01" y2="16" />
+      </svg>
+      <p className="text-red-600 font-semibold">{message}</p>
+    </div>
+  )
+}

--- a/frontend/src/components/ui/Spinner.jsx
+++ b/frontend/src/components/ui/Spinner.jsx
@@ -1,0 +1,9 @@
+import React from 'react'
+
+export default function Spinner({ className = '' }) {
+  return (
+    <div className={`flex justify-center items-center py-10 ${className}`}>
+      <div className="w-12 h-12 border-4 border-orange-600 border-t-transparent rounded-full animate-spin" />
+    </div>
+  )
+}

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -7,6 +7,8 @@ import SortDropdown from '../components/SortDropdown.jsx'
 import ProductCard from '../components/ProductCard.jsx'
 import { motion, AnimatePresence } from 'framer-motion'
 import SearchBar from '../components/SearchBar.jsx'
+import Spinner from '../components/ui/Spinner.jsx'
+import ErrorView from '../components/ui/ErrorView.jsx'
 
 export default function Home() {
   const location = useLocation()
@@ -85,8 +87,8 @@ export default function Home() {
     }
   }, [location.state])
 
-  if (loading) return <div>Cargando...</div>
-  if (error) return <div className="text-red-600">{error}</div>
+  if (loading) return <Spinner />
+  if (error) return <ErrorView message={error} />
 
   const listVariants = { hidden: {}, show: { transition: { staggerChildren: 0.05 } } }
   const itemVariants = { hidden: { opacity: 0, y: 8 }, show: { opacity: 1, y: 0 } }


### PR DESCRIPTION
## Summary
- Show animated spinner while products are loading
- Display a friendly error view when product fetching fails
- Implement reusable `Spinner` and `ErrorView` UI components

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c43c3d14d08330af290290ac9f6a6d