### PR TITLE
Fix routing for GitHub Pages subdirectory

### DIFF
--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -153,7 +153,7 @@ function App() {
           </div>
         </div>
         <div className="flex-1">
-          <BrowserRouter>
+          <BrowserRouter basename={base}>
             <Navbar />
             <div className="max-w-7xl mx-auto px-4 pt-24 pb-6">
               <Routes>


### PR DESCRIPTION
## Summary
- Add `basename` to `BrowserRouter` so the app works when hosted under `/marketOnline`

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c43eb1ebf083309592bbe498662bd0