### PR TITLE
chore: update repo links for rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Supermercado Monorepo (Backend + Frontend)
+Naranja Autoservicio Monorepo (Backend + Frontend)
 
 Estructura:
 

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,7 +1,7 @@
 const API_URL =
   import.meta.env.VITE_API_URL ||
   (import.meta.env.PROD
-    ? 'https://marketonline-production.up.railway.app/api'
+    ? 'https://naranja-autoservicio-production.up.railway.app/api'
     : 'http://localhost:8000/api')
 
 export async function getCategories() {

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -4,7 +4,7 @@ import history from 'connect-history-api-fallback'
 
 export default defineConfig({
   appType: 'spa',
-  base: '/marketOnline/',
+  base: '/naranja-autoservicio/',
   plugins: [
     react(),
     {


### PR DESCRIPTION
## Summary
- update GitHub Pages base path to new repository name
- point production API URL at new Railway deployment
- rename monorepo title

## Testing
- `DJANGO_SECRET_KEY=test DJANGO_ALLOWED_HOSTS=localhost,127.0.0.1 python manage.py test` (fails: AssertionError)
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68c43ff5cb748330b4ce04219d54773f