### PR TITLE
fix(frontend): update production API host

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,7 +1,7 @@
 const API_URL =
   import.meta.env.VITE_API_URL ||
   (import.meta.env.PROD
-    ? 'https://naranja-autoservicio-production.up.railway.app/api'
+    ? 'https://marketonline-production.up.railway.app/api'
     : 'http://localhost:8000/api')
 
 export async function getCategories() {


### PR DESCRIPTION
## Summary
- point production API calls to `marketonline-production.up.railway.app`

## Testing
- `DJANGO_SECRET_KEY=test DJANGO_ALLOWED_HOSTS=localhost python manage.py test` *(fails: CouponValidateViewTest.test_requires_authentication 200 != 403)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c44ca36448833091350289bf9bc17b