### PR TITLE
Prioritize discounted products

### DIFF
--- a/backend/shop/views.py
+++ b/backend/shop/views.py
@@ -40,13 +40,20 @@ class ProductPagination(PageNumberPagination):
 
 
 class ProductViewSet(mixins.ListModelMixin, mixins.RetrieveModelMixin, viewsets.GenericViewSet):
-    queryset = Product.objects.filter(is_active=True).select_related('category')
+    queryset = Product.objects.filter(is_active=True).annotate(
+        has_offer=models.Case(
+            models.When(offer_price__isnull=False, then=models.Value(0)),
+            default=models.Value(1),
+            output_field=models.IntegerField(),
+        )
+    ).select_related('category')
     serializer_class = ProductSerializer
     permission_classes = [AllowAny]
     filter_backends = [DjangoFilterBackend, SearchFilter, OrderingFilter]
     filterset_fields = ['category', 'promoted']
     search_fields = ['name', 'description']
-    ordering_fields = ['name', 'price', 'offer_price', 'created_at']
+    ordering_fields = ['name', 'price', 'offer_price', 'created_at', 'has_offer']
+    ordering = ('has_offer', 'offer_price')
     pagination_class = ProductPagination
 
 

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -44,7 +44,7 @@ export default function Home() {
     setLoading(true)
     const orderingMap = {
       recent: '-created_at',
-      discount: '-offer_price',
+      discount: 'has_offer,offer_price',
       price_high: '-price',
       price_low: 'price',
       name_az: 'name',


### PR DESCRIPTION
## Summary
- annotate products with `has_offer` and sort discounted items first
- expose new `has_offer` ordering to frontend
- use new ordering in home page discount sort option

## Testing
- `DJANGO_SECRET_KEY=test DJANGO_ALLOWED_HOSTS=localhost python manage.py test` *(fails: CouponValidateViewTest test_requires_authentication expected 403, got 200)*
- `npm run build`
- `DJANGO_SECRET_KEY=test DJANGO_ALLOWED_HOSTS=localhost python - <<'PY' ...`

------
https://chatgpt.com/codex/tasks/task_e_68c7fb1852fc833090c2f417f82a3ca9