### PR TITLE
Alternate cart reminder with page name

### DIFF
--- a/frontend/src/store/cart.jsx
+++ b/frontend/src/store/cart.jsx
@@ -62,11 +62,18 @@ export function CartProvider({ children }) {
   )
   const count = useMemo(() => items.reduce((acc, it) => acc + it.quantity, 0), [items])
 
-    useEffect(() => {
+  useEffect(() => {
     const originalTitle = 'Naranja Autoservicio'
+    let interval
     const handleVisibility = () => {
+      clearInterval(interval)
       if (document.hidden && count > 0) {
         document.title = '¡Volvé por tu carrito!'
+        let showCartTitle = false
+        interval = setInterval(() => {
+          document.title = showCartTitle ? '¡Volvé por tu carrito!' : originalTitle
+          showCartTitle = !showCartTitle
+        }, 5000)
       } else {
         document.title = originalTitle
       }
@@ -75,6 +82,7 @@ export function CartProvider({ children }) {
     handleVisibility()
     return () => {
       document.removeEventListener('visibilitychange', handleVisibility)
+      clearInterval(interval)
       document.title = originalTitle
     }
   }, [count])


### PR DESCRIPTION
## Summary
- Alternate browser tab title between cart reminder and site name every 5 seconds when page is hidden and cart has items

## Testing
- `npm test` (missing script: test)
- `npm run build`
- `python manage.py test` (DJANGO_SECRET_KEY must be set)


------
https://chatgpt.com/codex/tasks/task_e_68c7fc5b05d48330b3e07a2b073e8942