### PR TITLE
Show blurred address field for pickup and highlight offer prices

### DIFF
--- a/frontend/src/components/ProductCard.jsx
+++ b/frontend/src/components/ProductCard.jsx
@@ -49,7 +49,7 @@ export default function ProductCard({ product }) {
         {product.offer_price && Number(product.offer_price) < Number(product.price) ? (
           <div>
             <div className="text-sm line-through text-slate-400">${Number(product.price).toFixed(2)}</div>
-            <div className="font-bold text-lg text-red-700 dark:text-red-600">${Number(product.offer_price).toFixed(2)}</div>
+            <div className="font-bold text-lg text-red-600 dark:text-red-500">${Number(product.offer_price).toFixed(2)}</div>
           </div>
         ) : (
           <div className="font-bold text-lg text-orange-500">${Number(product.price).toFixed(2)}</div>

--- a/frontend/src/components/cart/CartGrouped.jsx
+++ b/frontend/src/components/cart/CartGrouped.jsx
@@ -104,7 +104,7 @@ export default function CartGrouped({
 
                     {/* Precio unitario desktop */}
                     <div className="hidden min-[1000px]:flex flex-col items-start justify-center">
-                      <span className="font-semibold text-orange-600 whitespace-nowrap">{formatArs(unit)}</span>
+                      <span className={["font-semibold whitespace-nowrap", hasOffer ? 'text-red-600 dark:text-red-500' : 'text-orange-600'].join(' ')}>{formatArs(unit)}</span>
                       {hasOffer && (
                         <span className="text-xs text-gray-500 line-through whitespace-nowrap">{formatArs(product.price)}</span>
                       )}
@@ -127,7 +127,7 @@ export default function CartGrouped({
                     {/* Total + eliminar desktop */}
 
                     <div className="hidden min-[1000px]:flex items-center justify-end pr-2 gap-2">
-                      <span className="font-semibold text-orange-600 whitespace-nowrap">{formatArs(lineTotal)}</span>
+                      <span className={["font-semibold whitespace-nowrap", hasOffer ? 'text-red-600 dark:text-red-500' : 'text-orange-600'].join(' ')}>{formatArs(lineTotal)}</span>
                       <button
                         onClick={() => onRemove(product.id)}
                         className="text-orange-600 hover:text-orange-700"
@@ -167,7 +167,7 @@ export default function CartGrouped({
 
                     {/* Total mobile */}
                     <div className="min-[1000px]:hidden row-start-2 col-start-2 flex items-center justify-end">
-                      <span className="font-semibold text-orange-600 whitespace-nowrap text-lg">{formatArs(lineTotal)}</span>
+                      <span className={["font-semibold whitespace-nowrap text-lg", hasOffer ? 'text-red-600 dark:text-red-500' : 'text-orange-600'].join(' ')}>{formatArs(lineTotal)}</span>
                     </div>
 
 

--- a/frontend/src/pages/Checkout.jsx
+++ b/frontend/src/pages/Checkout.jsx
@@ -309,20 +309,25 @@ export default function Checkout() {
               <input name="name" value={form.name} onChange={onChange} className="border rounded px-3 py-2 border-gray-300 bg-white text-gray-900 placeholder-gray-400 focus:ring-2 focus:ring-orange-500 focus:border-orange-500 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100" placeholder="Nombre" required />
               <input name="phone" value={form.phone} onChange={onChange} className="border rounded px-3 py-2 border-gray-300 bg-white text-gray-900 placeholder-gray-400 focus:ring-2 focus:ring-orange-500 focus:border-orange-500 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100" placeholder="Teléfono" required />
             </div>
-            {form.delivery_method === 'delivery' ? (
+            <div className="relative">
               <input
                 name="address"
                 value={form.address}
                 onChange={onChange}
-                className="border rounded px-3 py-2 w-full border-gray-300 bg-white text-gray-900 placeholder-gray-400 focus:ring-2 focus:ring-orange-500 focus:border-orange-500 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100"
+                disabled={form.delivery_method === 'pickup'}
+                className={[
+                  'border rounded px-3 py-2 w-full border-gray-300 bg-white text-gray-900 placeholder-gray-400 focus:ring-2 focus:ring-orange-500 focus:border-orange-500 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100',
+                  form.delivery_method === 'pickup' ? 'opacity-50 blur-[1px]' : ''
+                ].join(' ')}
                 placeholder="Dirección"
-                required
+                required={form.delivery_method === 'delivery'}
               />
-            ) : (
-              <p className="text-sm text-slate-600 dark:text-slate-300 px-1">
-                No es necesaria la dirección para retiro en tienda.
-              </p>
-            )}
+              {form.delivery_method === 'pickup' && (
+                <div className="pointer-events-none absolute inset-0 flex items-center justify-center text-sm text-slate-600 dark:text-slate-300 bg-white/70 dark:bg-gray-900/70 rounded">
+                  No es necesaria la dirección para retiro en tienda.
+                </div>
+              )}
+            </div>
             <textarea name="notes" value={form.notes} onChange={onChange} className="border rounded px-3 py-2 w-full border-gray-300 bg-white text-gray-900 placeholder-gray-400 focus:ring-2 focus:ring-orange-500 focus:border-orange-500 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100" placeholder="Notas (opcional)" />
 
             <div className="flex items-center gap-4">

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -173,7 +173,7 @@ export default function Home() {
                           {p.image ? <img src={p.image} alt={p.name} className="w-full h-full object-cover" /> : null}
                         </div>
                         <div className="text-sm font-semibold truncate">{p.name}</div>
-                        <div className="text-xs text-slate-500">${Number(p.offer_price ?? p.price).toFixed(2)}</div>
+                        <div className={["text-xs", p.offer_price && Number(p.offer_price) < Number(p.price) ? 'text-red-600 dark:text-red-500' : 'text-slate-500'].join(' ')}>${Number(p.offer_price ?? p.price).toFixed(2)}</div>
                       </button>
                     ))}
                   {products.filter(p => (p.name + ' ' + (p.description || '')).toLowerCase().includes(search.toLowerCase())).length === 0 && (


### PR DESCRIPTION
## Summary
- Keep address input visible for pickup orders with blurred styling and overlay message
- Intensify red styling for products on offer across cards, cart and search suggestions

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c7fddc6f688330895d9eca8c106dba