### PR TITLE
Handle errors when deleting product images

### DIFF
--- a/backend/shop/models.py
+++ b/backend/shop/models.py
@@ -1,7 +1,11 @@
-from django.db import models
+import logging
+
 from django.core.cache import cache
+from django.db import models
 from django.db.models.signals import post_save, post_delete, pre_save
 from django.dispatch import receiver
+
+logger = logging.getLogger(__name__)
 
 SITE_CONFIG_CACHE_KEY = 'site_config'
 SITE_CONFIG_CACHE_TIMEOUT = 60 * 5
@@ -143,7 +147,10 @@ def clear_site_config_cache(**kwargs):
 def delete_product_image_on_delete(sender, instance, **kwargs):
     """Ensure images are removed from Cloudinary when a product is deleted."""
     if instance.image:
-        instance.image.delete(save=False)
+        try:
+            instance.image.delete(save=False)
+        except Exception:
+            logger.exception("Error deleting product image on delete")
 
 
 @receiver(pre_save, sender=Product)
@@ -157,4 +164,7 @@ def delete_old_product_image_on_change(sender, instance, **kwargs):
         return
     new_image = instance.image
     if old_image and old_image != new_image:
-        old_image.delete(save=False)
+        try:
+            old_image.delete(save=False)
+        except Exception:
+            logger.exception("Error deleting old product image on update")


### PR DESCRIPTION
## Summary
- add module logger for shop models
- wrap product image deletions in try/except to log failures

## Testing
- `DJANGO_SECRET_KEY=testsecret DJANGO_ALLOWED_HOSTS=localhost python manage.py test` (fails: `test_requires_authentication`)


------
https://chatgpt.com/codex/tasks/task_e_68c8016e32408330976738415cf15017