### PR TITLE
Add tests for product image cleanup

### DIFF
--- a/backend/shop/tests/test_product_image_cleanup.py
+++ b/backend/shop/tests/test_product_image_cleanup.py
@@ -1,0 +1,40 @@
+from unittest.mock import patch
+
+from django.test import TestCase
+
+from shop.models import Category, Product
+
+
+class ProductImageCleanupTests(TestCase):
+    def setUp(self):
+        self.category = Category.objects.create(name="Cat", slug="cat")
+
+    @patch("cloudinary_storage.storage.MediaCloudinaryStorage.delete", autospec=True)
+    def test_deleting_product_removes_cloudinary_image(self, mock_delete):
+        product = Product.objects.create(
+            category=self.category,
+            name="Prod",
+            price=10,
+            image="products/test.jpg",
+        )
+
+        product.delete()
+
+        mock_delete.assert_called_once()
+        self.assertEqual(mock_delete.call_args[0][1], "products/test.jpg")
+
+    @patch("cloudinary_storage.storage.MediaCloudinaryStorage.delete", autospec=True)
+    def test_updating_product_image_replaces_old_file(self, mock_delete):
+        product = Product.objects.create(
+            category=self.category,
+            name="Prod",
+            price=10,
+            image="products/old.jpg",
+        )
+
+        product.image = "products/new.jpg"
+        product.save()
+
+        mock_delete.assert_called_once()
+        self.assertEqual(mock_delete.call_args[0][1], "products/old.jpg")
+        self.assertEqual(product.image.name, "products/new.jpg")


### PR DESCRIPTION
## Summary
- add tests ensuring product deletion removes its Cloudinary image
- add tests verifying image updates remove previous Cloudinary file

## Testing
- `DJANGO_SECRET_KEY=test DJANGO_DEBUG=1 python backend/manage.py test shop.tests.test_product_image_cleanup -v 2`
- `DJANGO_SECRET_KEY=test DJANGO_DEBUG=1 python backend/manage.py test shop -v 2` *(fails: CouponValidateViewTest.test_requires_authentication)*

------
https://chatgpt.com/codex/tasks/task_e_68c8016eea04833082665bb11e2e4480