### PR TITLE
Make coupon validation endpoint public

### DIFF
--- a/backend/shop/tests/test_coupon_validate_view.py
+++ b/backend/shop/tests/test_coupon_validate_view.py
@@ -46,14 +46,16 @@ class CouponValidateViewTest(TestCase):
         self.assertEqual(r.status_code, 200)
         self.assertEqual(r.json(), {"valid": False})
 
-    def test_requires_authentication(self):
+    def test_does_not_require_authentication(self):
         self.client.logout()
         r = self.client.post(
             "/api/coupons/validate/",
             {"code": "OFF10"},
             content_type="application/json",
         )
-        self.assertEqual(r.status_code, 403)
+        self.assertEqual(r.status_code, 200)
+        data = r.json()
+        self.assertTrue(data.get("valid"))
 
     def test_expired_coupon_invalid(self):
         expired = Coupon.objects.create(

--- a/backend/shop/views.py
+++ b/backend/shop/views.py
@@ -88,7 +88,7 @@ class OrderViewSet(mixins.CreateModelMixin, viewsets.GenericViewSet):
 class CouponValidateView(APIView):
     throttle_classes = [ScopedRateThrottle]
     throttle_scope = 'coupon_validate'
-    permission_classes = [IsAuthenticated]
+    permission_classes = [AllowAny]
 
     def post(self, request):
         code = request.data.get('code', '').strip()[:40]


### PR DESCRIPTION
## Summary
- Allow coupon validation endpoint to be accessed without authentication
- Update coupon validation tests accordingly

## Testing
- `DJANGO_SECRET_KEY=foo DJANGO_DEBUG=True python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68c80f16d5dc8330b2b9973ec9cefb58