### PR TITLE
Adjust product image rendering to prevent cropping

### DIFF
--- a/frontend/src/components/ProductCard.jsx
+++ b/frontend/src/components/ProductCard.jsx
@@ -35,7 +35,7 @@ export default function ProductCard({ product }) {
           <img
             src={product.image}
             alt={product.name}
-            className="w-full h-full object-cover object-center"
+            className="w-full h-full object-contain object-center"
           />
         ) : (
           <div className="text-sm text-gray-400 dark:text-gray-300 select-none">

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -170,7 +170,7 @@ export default function Home() {
                         className="text-left rounded-lg border border-orange-600/40 bg-white dark:bg-[#020617] p-2 hover:shadow-md hover:border-orange-600 transition"
                       >
                         <div className="aspect-[4/3] rounded-md overflow-hidden bg-gray-100 dark:bg-gray-700 mb-2">
-                          {p.image ? <img src={p.image} alt={p.name} className="w-full h-full object-cover" /> : null}
+                          {p.image ? <img src={p.image} alt={p.name} className="w-full h-full object-contain" /> : null}
                         </div>
                         <div className="text-sm font-semibold truncate">{p.name}</div>
                         <div className={["text-xs", p.offer_price && Number(p.offer_price) < Number(p.price) ? 'text-red-600 dark:text-red-500' : 'text-slate-500'].join(' ')}>${Number(p.offer_price ?? p.price).toFixed(2)}</div>


### PR DESCRIPTION
## Summary
- render product card images with `object-contain` to avoid cropping while keeping centering
- update search preview images to use the same containment for consistent presentation

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946ad96e5f08330a6da60a25f25a9d3)